### PR TITLE
update image requestor to use info.json that is returned

### DIFF
--- a/lib/shimmy/image_requestor.rb
+++ b/lib/shimmy/image_requestor.rb
@@ -6,29 +6,36 @@ module Shimmy
   # IIIFifies a static image url
   class ImageRequestor
     IIIFIFY_SERVICE = 'http://dlss-dev-azaroth.stanford.edu/services/iiif/submit'
-
+    attr_reader :response
     ##
     # @param {String} request_url Url to be IIIFified
     # @param {String} iiifify_service a Iiifify service url
     def initialize(request_url, iiifify_service = IIIFIFY_SERVICE)
       @request_url = request_url
       @iiifify_service = iiifify_service
+      @response = parse_response
     end
 
-    ##
-    # @return {String} a Iiifified url
-    def iiifify
-      parse_response
+    def service_url
+      @response['@id']
     end
 
     def profile
-      'http://iiif.io/api/image/2/level2.json'
+      @repsonse['profile'][0]
+    end
+
+    def width
+      @response['width']
+    end
+
+    def height
+      @response['height']
     end
 
     private
 
     def parse_response
-      JSON.parse(iiif_service.body)['url']
+      JSON.parse(iiif_service.body)
     end
 
     ##
@@ -36,7 +43,7 @@ module Shimmy
     def iiif_service
       response = Hurley.get(@iiifify_service, url: @request_url)
       fail 'Bad response' if response.status_code != 200
-      fail 'Incorrect content type' if response.header['Content-Type'] != 'application/json'
+      fail 'Incorrect content type' if response.header['Content-Type'] != 'application/json' && response.header['Content-Type'] != 'application/ld+json'
       response
     end
   end

--- a/lib/shimmy/shims/flickr_set.rb
+++ b/lib/shimmy/shims/flickr_set.rb
@@ -37,7 +37,13 @@ module Shimmy
           canvas.label = photo.title
           canvas['@id'] = Shimmy::ImageRequestor.new(photo.url_o).iiifify
           anno = IIIF::Presentation::Annotation.new()
-          ic = IIIF::Presentation::ImageResource.create_image_api_image_resource(resource_id: photo.url_o, service_id: Shimmy::ImageRequestor.new(photo.url_o).iiifify)
+          iiifified = Shimmy::ImageRequestor.new(photo.url_o)
+          ic = IIIF::Presentation::ImageResource.create_image_api_image_resource(
+            resource_id: photo.url_o,
+            service_id: iiifified.service_url,
+            width: iiifified.width,
+            height: iiifified.height
+          )
           anno.resource = ic
           canvas.images << anno
           sequence.canvases << canvas

--- a/lib/shimmy/shims/jsc_image_collection.rb
+++ b/lib/shimmy/shims/jsc_image_collection.rb
@@ -24,7 +24,7 @@ module Shimmy
           searchpage: true,
           selections: 'AS13',
           browsepage: 'Go',
-          hitsperpage: 200,
+          hitsperpage: 2,
           'submit.x' => 0,
           'submit.y' => 0,
           submit: 'submit'
@@ -46,7 +46,12 @@ module Shimmy
           canvas.label = row.label
           canvas['@id'] = row.image_url
           anno = IIIF::Presentation::Annotation.new()
-          ic = IIIF::Presentation::ImageResource.create_image_api_image_resource(resource_id: row.static_image, service_id: row.image_url)
+          ic = IIIF::Presentation::ImageResource.create_image_api_image_resource(
+            resource_id: row.static_image,
+            service_id: row.image_url,
+            width: row.image_requestor.width,
+            height: row.image_requestor.height
+          )
           anno.resource = ic
           canvas.images << anno
           sequence.canvases << canvas
@@ -99,7 +104,7 @@ module Shimmy
       end
 
       def image_url
-        image_requestor.iiifify
+        image_requestor.service_url
       end
 
       def width


### PR DESCRIPTION
The iiifify service was modified to return an image's info.json on redirect rather than the url, this pr enhances the api to use this information to reduce HTTP overhead.
